### PR TITLE
chore: release v2024.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [2024.2.9](https://github.com/stvnksslr/uv-migrator/compare/v2024.2.8...v2024.2.9) - 2024-10-10
+
+### Added
+- *(workflow fixes + removing goreleaser)* goreleaser is really cool but its a bit of an odd hoop jump for releaser (by @stvnksslr)
+
+### Contributors
+
+* @stvnksslr
 ## [2024.2.8](https://github.com/stvnksslr/uv-migrator/compare/v2024.2.7...v2024.2.8) - 2024-10-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,7 +326,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uv-migrator"
-version = "2024.2.8"
+version = "2024.2.9"
 dependencies = [
  "env_logger",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-migrator"
-version = "2024.2.8"
+version = "2024.2.9"
 edition = "2021"
 authors = ["stvnksslr@gmail.com"]
 description = "Tool for converting various python package soltutions to use the uv solution by astral"


### PR DESCRIPTION
## 🤖 New release
* `uv-migrator`: 2024.2.8 -> 2024.2.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2024.2.9](https://github.com/stvnksslr/uv-migrator/compare/v2024.2.8...v2024.2.9) - 2024-10-10

### Added
- *(workflow fixes + removing goreleaser)* goreleaser is really cool but its a bit of an odd hoop jump for releaser (by @stvnksslr)

### Contributors

* @stvnksslr
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).