### PR TITLE
chore: release v2024.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [2024.3.0](https://github.com/stvnksslr/uv-migrator/compare/v2024.2.11...v2024.3.0) - 2024-10-10
+
+### Added
+- *(pip)* requirements.txt is handled better + cases with no existing pyproject.toml is handled (by @stvnksslr)
+
+### Other
+- *(readme)* adding pipenv to scope of migration (by @stvnksslr)
+- *(migrator)* extracting logic and breaking each implementation into more focused implementations (by @stvnksslr)
+
+### Contributors
+
+* @stvnksslr
 ## [2024.2.11](https://github.com/stvnksslr/uv-migrator/compare/v2024.2.10...v2024.2.11) - 2024-10-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -326,7 +326,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uv-migrator"
-version = "2024.2.11"
+version = "2024.3.0"
 dependencies = [
  "env_logger",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-migrator"
-version = "2024.2.11"
+version = "2024.3.0"
 edition = "2021"
 authors = ["stvnksslr@gmail.com"]
 description = "Tool for converting various python package soltutions to use the uv solution by astral"


### PR DESCRIPTION
## 🤖 New release
* `uv-migrator`: 2024.2.11 -> 2024.3.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2024.3.0](https://github.com/stvnksslr/uv-migrator/compare/v2024.2.11...v2024.3.0) - 2024-10-10

### Added
- *(pip)* requirements.txt is handled better + cases with no existing pyproject.toml is handled (by @stvnksslr)

### Other
- *(readme)* adding pipenv to scope of migration (by @stvnksslr)
- *(migrator)* extracting logic and breaking each implementation into more focused implementations (by @stvnksslr)

### Contributors

* @stvnksslr
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).