### PR TITLE
chore: release v2025.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [2025.0.0](https://github.com/stvnksslr/uv-migrator/compare/v2024.6.0...v2025.0.0) - 2024-11-15
+
+### Added
+- *(dependency groups)* dependency groups are now properly supported by uv, if you are using some form of grouping requirements-test.txt or poetry  [tool.poetry.group.test.dependencies] these will now carry over, if you are not using them everything will fall under --dev as normal (by @stvnksslr)
+
+### Fixed
+- *(poetry)* was not clearly translating poetry dep groups to uv ones in many circumstances (by @stvnksslr)
+
+### Other
+- chore(gitignore tweaks): (by @stvnksslr)
+- chore(gitignore tweaks): (by @stvnksslr)
+
+### Contributors
+
+* @stvnksslr
 ## [2024.6.0](https://github.com/stvnksslr/uv-migrator/compare/v2024.5.4...v2024.6.0) - 2024-11-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1963,7 +1963,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uv-migrator"
-version = "2024.6.0"
+version = "2025.0.0"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-migrator"
-version = "2024.6.0"
+version = "2025.0.0"
 edition = "2021"
 authors = ["stvnksslr@gmail.com"]
 description = "Tool for converting various python package soltutions to use the uv solution by astral"


### PR DESCRIPTION
## 🤖 New release
* `uv-migrator`: 2024.6.0 -> 2025.0.0 (⚠️ API breaking changes)

### ⚠️ `uv-migrator` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_variant_added.ron

Failed in:
  variant DependencyType:Group in /tmp/.tmph0wb9l/uv-migrator/src/migrators/dependency.rs:6
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2025.0.0](https://github.com/stvnksslr/uv-migrator/compare/v2024.6.0...v2025.0.0) - 2024-11-15

### Added
- *(dependency groups)* dependency groups are now properly supported by uv, if you are using some form of grouping requirements-test.txt or poetry  [tool.poetry.group.test.dependencies] these will now carry over, if you are not using them everything will fall under --dev as normal (by @stvnksslr)

### Fixed
- *(poetry)* was not clearly translating poetry dep groups to uv ones in many circumstances (by @stvnksslr)

### Other
- chore(gitignore tweaks): (by @stvnksslr)
- chore(gitignore tweaks): (by @stvnksslr)

### Contributors

* @stvnksslr
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).