### PR TITLE
chore: release v2024.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [2024.8.2](https://github.com/stvnksslr/uv-migrator/compare/v2024.8.1...v2024.8.2) - 2024-12-10
+
+### Fixed
+- *(pyproject)* existing description and version fields were not being carried over correctly, this has been fixed (by @stvnksslr)
+
+### Other
+- chore(naming fixes): (by @stvnksslr)
+- chore(naming for ci workflow): (by @stvnksslr)
+- chore(naming for ci workflow): (by @stvnksslr)
+- chore(rust format): (by @stvnksslr)
+- *(doc strings)* added docstrings for tests (by @stvnksslr)
+
+### Contributors
+
+* @stvnksslr
 ## [2024.8.1](https://github.com/stvnksslr/uv-migrator/compare/v2024.8.0...v2024.8.1) - 2024-12-02
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1797,7 +1797,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uv-migrator"
-version = "2024.8.1"
+version = "2024.8.2"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-migrator"
-version = "2024.8.1"
+version = "2024.8.2"
 edition = "2021"
 authors = ["stvnksslr@gmail.com"]
 description = "Tool for converting various python package soltutions to use the uv solution by astral"


### PR DESCRIPTION
## 🤖 New release
* `uv-migrator`: 2024.8.1 -> 2024.8.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2024.8.2](https://github.com/stvnksslr/uv-migrator/compare/v2024.8.1...v2024.8.2) - 2024-12-10

### Fixed
- *(pyproject)* existing description and version fields were not being carried over correctly, this has been fixed (by @stvnksslr)

### Other
- chore(naming fixes): (by @stvnksslr)
- chore(naming for ci workflow): (by @stvnksslr)
- chore(naming for ci workflow): (by @stvnksslr)
- chore(rust format): (by @stvnksslr)
- *(doc strings)* added docstrings for tests (by @stvnksslr)

### Contributors

* @stvnksslr
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).