### PR TITLE
chore: release v2025.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [2025.0.0](https://github.com/stvnksslr/uv-migrator/compare/v2024.8.2...v2025.0.0) - 2024-12-14
+
+### Added
+- *(install.sh)* simplified and condensed logic as much as possible so the script is easily auditable (by @stvnksslr)
+- *(merge dep groups)* since uv follows its own behavoir and treats additional groups as optional added the ability to merge dep groups into -dev for ease of use (by @stvnksslr)
+
+### Fixed
+- *(release)* messing with security settings (by @stvnksslr)
+- *(zizmor)* used zizmor to find and fix all security related warnings (by @stvnksslr)
+- *(readme)* install.sh link was wring (by @stvnksslr)
+
+### Other
+- chore(readme update + install script in repo): (by @stvnksslr)
+
+### Contributors
+
+* @stvnksslr
 ## [2024.8.2](https://github.com/stvnksslr/uv-migrator/compare/v2024.8.1...v2024.8.2) - 2024-12-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1797,7 +1797,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uv-migrator"
-version = "2024.8.2"
+version = "2025.0.0"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-migrator"
-version = "2024.8.2"
+version = "2025.0.0"
 edition = "2021"
 authors = ["stvnksslr@gmail.com"]
 description = "Tool for converting various python package soltutions to use the uv solution by astral"


### PR DESCRIPTION
## 🤖 New release
* `uv-migrator`: 2024.8.2 -> 2025.0.0 (⚠️ API breaking changes)

### ⚠️ `uv-migrator` breaking changes

```
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/function_parameter_count_changed.ron

Failed in:
  uv_migrator::migrators::run_migration now takes 4 parameters instead of 3, in /tmp/.tmpz2Oqb8/uv-migrator/src/migrators/mod.rs:170
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2025.0.0](https://github.com/stvnksslr/uv-migrator/compare/v2024.8.2...v2025.0.0) - 2024-12-14

### Added
- *(install.sh)* simplified and condensed logic as much as possible so the script is easily auditable (by @stvnksslr)
- *(merge dep groups)* since uv follows its own behavoir and treats additional groups as optional added the ability to merge dep groups into -dev for ease of use (by @stvnksslr)

### Fixed
- *(release)* messing with security settings (by @stvnksslr)
- *(zizmor)* used zizmor to find and fix all security related warnings (by @stvnksslr)
- *(readme)* install.sh link was wring (by @stvnksslr)

### Other
- chore(readme update + install script in repo): (by @stvnksslr)

### Contributors

* @stvnksslr
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).