### PR TITLE
chore: release v2025.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [2025.2.3](https://github.com/stvnksslr/uv-migrator/compare/v2025.2.2...v2025.2.3) - 2024-12-26
+
+### Other
+- wip(goreleaser): (by @stvnksslr)
+
+### Contributors
+
+* @stvnksslr
 ## [2025.2.2](https://github.com/stvnksslr/uv-migrator/compare/v2025.2.1...v2025.2.2) - 2024-12-26
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1782,7 +1782,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uv-migrator"
-version = "2025.2.2"
+version = "2025.2.3"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-migrator"
-version = "2025.2.2"
+version = "2025.2.3"
 edition = "2021"
 authors = ["stvnksslr@gmail.com"]
 description = "Tool for converting various python package soltutions to use the uv solution by astral"


### PR DESCRIPTION
## 🤖 New release
* `uv-migrator`: 2025.2.2 -> 2025.2.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2025.2.3](https://github.com/stvnksslr/uv-migrator/compare/v2025.2.2...v2025.2.3) - 2024-12-26

### Other
- wip(goreleaser): (by @stvnksslr)

### Contributors

* @stvnksslr
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).