### PR TITLE
chore: release v2026.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [2026.0.0](https://github.com/stvnksslr/uv-migrator/compare/v2025.2.7...v2026.0.0) - 2024-12-28
+
+### Added
+- *(removing venv step)* explicitly creating a virtual env is not really needed and will be taken care of by other steps (by @stvnksslr)
+
+### Contributors
+
+* @stvnksslr
 ## [2025.2.7](https://github.com/stvnksslr/uv-migrator/compare/v2025.2.6...v2025.2.7) - 2024-12-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1804,7 +1804,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uv-migrator"
-version = "2025.2.7"
+version = "2026.0.0"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-migrator"
-version = "2025.2.7"
+version = "2026.0.0"
 edition = "2021"
 authors = ["stvnksslr@gmail.com"]
 description = "Tool for converting various python package soltutions to use the uv solution by astral"


### PR DESCRIPTION
## 🤖 New release
* `uv-migrator`: 2025.2.7 -> 2026.0.0 (⚠️ API breaking changes)

### ⚠️ `uv-migrator` breaking changes

```
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/function_missing.ron

Failed in:
  function uv_migrator::utils::create_virtual_environment, previously in file /tmp/.tmpUDC1kc/uv-migrator/src/utils/venv.rs:4
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2026.0.0](https://github.com/stvnksslr/uv-migrator/compare/v2025.2.7...v2026.0.0) - 2024-12-28

### Added
- *(removing venv step)* explicitly creating a virtual env is not really needed and will be taken care of by other steps (by @stvnksslr)

### Contributors

* @stvnksslr
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).