### PR TITLE
chore: release v2025.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [2025.3.1](https://github.com/stvnksslr/uv-migrator/compare/v2025.3.0...v2025.3.1) - 2025-01-01
+
+### Fixed
+- *(clippy)* fixed some clippy warnings (by @stvnksslr)
+
+### Other
+- *(dependencies)* self_update released a needed bump .41 -> 42 (by @stvnksslr)
+
+### Contributors
+
+* @stvnksslr
 ## [2025.2.7](https://github.com/stvnksslr/uv-migrator/compare/v2025.2.6...v2025.2.7) - 2024-12-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1844,7 +1844,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uv-migrator"
-version = "2025.3.0"
+version = "2025.3.1"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-migrator"
-version = "2025.3.0"
+version = "2025.3.1"
 edition = "2021"
 authors = ["stvnksslr@gmail.com"]
 description = "Tool for converting various python package soltutions to use the uv solution by astral"


### PR DESCRIPTION
## 🤖 New release
* `uv-migrator`: 2025.3.0 -> 2025.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2025.3.1](https://github.com/stvnksslr/uv-migrator/compare/v2025.3.0...v2025.3.1) - 2025-01-01

### Fixed
- *(clippy)* fixed some clippy warnings (by @stvnksslr)

### Other
- *(dependencies)* self_update released a needed bump .41 -> 42 (by @stvnksslr)

### Contributors

* @stvnksslr
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).