### PR TITLE
chore: release v2025.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [2025.3.4](https://github.com/stvnksslr/uv-migrator/compare/v2025.3.3...v2025.3.4) - 2025-01-07
+
+### Added
+- *(poetry authors)* solves issue #49, support for migrating authors was only for setup.py but now supports poetry properly as well (by @stvnksslr)
+
+### Other
+- *(poetry indexes)* there was an order of operations bug that was filtering the indexes out before they could be migrated introduced in a recent version, this fixes it and also fixes #50 (by @stvnksslr)
+
+### Contributors
+
+* @stvnksslr
 ## [2025.3.3](https://github.com/stvnksslr/uv-migrator/compare/v2025.3.2...v2025.3.3) - 2025-01-03
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1844,7 +1844,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uv-migrator"
-version = "2025.3.3"
+version = "2025.3.4"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-migrator"
-version = "2025.3.3"
+version = "2025.3.4"
 edition = "2021"
 authors = ["stvnksslr@gmail.com"]
 description = "Tool for converting various python package soltutions to use the uv solution by astral"


### PR DESCRIPTION
## 🤖 New release
* `uv-migrator`: 2025.3.3 -> 2025.3.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2025.3.4](https://github.com/stvnksslr/uv-migrator/compare/v2025.3.3...v2025.3.4) - 2025-01-07

### Added
- *(poetry authors)* solves issue #49, support for migrating authors was only for setup.py but now supports poetry properly as well (by @stvnksslr)

### Other
- *(poetry indexes)* there was an order of operations bug that was filtering the indexes out before they could be migrated introduced in a recent version, this fixes it and also fixes #50 (by @stvnksslr)

### Contributors

* @stvnksslr
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).