### PR TITLE
chore: release v2025.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [2025.4.0](https://github.com/stvnksslr/uv-migrator/compare/v2025.3.4...v2025.4.0) - 2025-01-15
+
+### Added
+- *(#53)* will attempt to init the uv project with any version information we can find in the previous packaging tool, if it doesnt find any will set the default python in the users path as is the default in uv (by @stvnksslr)
+- *(#51)* adds new build system migration only supports poetry currently (by @stvnksslr)
+- *(refactor)* alot of small bugs were cropping up from complex project setups that had lots of different files we were tracking, to make this easier to manage logic wise eveything has been broken into specific migration logic (by @stvnksslr)
+
+### Fixed
+- *(python version detection)* simplified logic to increase the chances of uv finding a python version within the range, ie 3.11 should find any installed 3.11 versions. (by @stvnksslr)
+
+### Other
+- chore(changing semver checks in releaseplz): (by @stvnksslr)
+
+### Contributors
+
+* @stvnksslr
 ## [2025.3.4](https://github.com/stvnksslr/uv-migrator/compare/v2025.3.3...v2025.3.4) - 2025-01-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1852,7 +1852,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uv-migrator"
-version = "2025.3.4"
+version = "2025.4.0"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-migrator"
-version = "2025.3.4"
+version = "2025.4.0"
 edition = "2021"
 authors = ["stvnksslr@gmail.com"]
 description = "Tool for converting various python package soltutions to use the uv solution by astral"


### PR DESCRIPTION
## 🤖 New release
* `uv-migrator`: 2025.3.4 -> 2025.4.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2025.4.0](https://github.com/stvnksslr/uv-migrator/compare/v2025.3.4...v2025.4.0) - 2025-01-15

### Added
- *(#53)* will attempt to init the uv project with any version information we can find in the previous packaging tool, if it doesnt find any will set the default python in the users path as is the default in uv (by @stvnksslr)
- *(#51)* adds new build system migration only supports poetry currently (by @stvnksslr)
- *(refactor)* alot of small bugs were cropping up from complex project setups that had lots of different files we were tracking, to make this easier to manage logic wise eveything has been broken into specific migration logic (by @stvnksslr)

### Fixed
- *(python version detection)* simplified logic to increase the chances of uv finding a python version within the range, ie 3.11 should find any installed 3.11 versions. (by @stvnksslr)

### Other
- chore(changing semver checks in releaseplz): (by @stvnksslr)

### Contributors

* @stvnksslr
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).