### PR TITLE
chore: release v2025.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [2025.6.2](https://github.com/stvnksslr/uv-migrator/compare/v2025.6.1...v2025.6.2) - 2025-02-23
+
+### Fixed
+- *(#63)* add warning to explain why this was done (by @stvnksslr)
+- *(#63)* fix edge case with uv creating a base python script that can clash with system python (by @stvnksslr)
+
+### Other
+- *(clippy --fix issue)* when updating to the rust 2024 edition clippy overzelously removed a logging config (by @stvnksslr)
+- *(clippy --fix issue)* when updating to the rust 2024 edition clippy overzelously removed a logging config (by @stvnksslr)
+
+### Contributors
+
+* @stvnksslr
 ## [2025.6.1](https://github.com/stvnksslr/uv-migrator/compare/v2025.6.0...v2025.6.1) - 2025-02-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,7 +1837,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uv-migrator"
-version = "2025.6.1"
+version = "2025.6.2"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-migrator"
-version = "2025.6.1"
+version = "2025.6.2"
 edition = "2024"
 authors = ["stvnksslr@gmail.com"]
 description = "Tool for converting various python package soltutions to use the uv solution by astral"


### PR DESCRIPTION



## 🤖 New release

* `uv-migrator`: 2025.6.1 -> 2025.6.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2025.6.2](https://github.com/stvnksslr/uv-migrator/compare/v2025.6.1...v2025.6.2) - 2025-02-23

### Fixed
- *(#63)* add warning to explain why this was done (by @stvnksslr)
- *(#63)* fix edge case with uv creating a base python script that can clash with system python (by @stvnksslr)

### Other
- *(clippy --fix issue)* when updating to the rust 2024 edition clippy overzelously removed a logging config (by @stvnksslr)
- *(clippy --fix issue)* when updating to the rust 2024 edition clippy overzelously removed a logging config (by @stvnksslr)

### Contributors

* @stvnksslr
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).