### PR TITLE
chore: release v2025.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [2025.6.4](https://github.com/stvnksslr/uv-migrator/compare/v2025.6.3...v2025.6.4) - 2025-02-25
+
+### Other
+- Feat/refactor v2 ([#67](https://github.com/stvnksslr/uv-migrator/pull/67)) (by @stvnksslr)
+
+### Contributors
+
+* @stvnksslr
 ## [2025.6.3](https://github.com/stvnksslr/uv-migrator/compare/v2025.6.2...v2025.6.3) - 2025-02-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,7 +1837,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uv-migrator"
-version = "2025.6.3"
+version = "2025.6.4"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-migrator"
-version = "2025.6.3"
+version = "2025.6.4"
 edition = "2024"
 authors = ["stvnksslr@gmail.com"]
 description = "Tool for converting various python package soltutions to use the uv solution by astral"


### PR DESCRIPTION



## 🤖 New release

* `uv-migrator`: 2025.6.3 -> 2025.6.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2025.6.4](https://github.com/stvnksslr/uv-migrator/compare/v2025.6.3...v2025.6.4) - 2025-02-25

### Other
- Feat/refactor v2 ([#67](https://github.com/stvnksslr/uv-migrator/pull/67)) (by @stvnksslr)

### Contributors

* @stvnksslr
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).