### PR TITLE
chore: release v2025.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [2025.8.0](https://github.com/stvnksslr/uv-migrator/compare/v2025.7.1...v2025.8.0) - 2025-05-24
+
+### Added
+- feat([#72](https://github.com/stvnksslr/uv-migrator/pull/72)): adding named indexes functionality (by @stvnksslr)
+- *(conda)* adding conda support (by @stvnksslr)
+
+### Fixed
+- fix([#76](https://github.com/stvnksslr/uv-migrator/pull/76)): didnt have correct logic for hatch conversion (by @stvnksslr)
+- add indexes before installing dependencies ([#73](https://github.com/stvnksslr/uv-migrator/pull/73)) (by @benedikt-bartscher)
+
+### Other
+- *(readme)* changing install url to support additional tools distributed from the same bucket/domain (by @stvnksslr)
+- *(readme)* changing install url to support additional tools distributed from the same bucket/domain (by @stvnksslr)
+- chore(cleaning up comments): (by @stvnksslr)
+
+### Contributors
+
+* @stvnksslr
+* @benedikt-bartscher
 ## [2025.7.1](https://github.com/stvnksslr/uv-migrator/compare/v2025.7.0...v2025.7.1) - 2025-02-27
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uv-migrator"
-version = "2025.7.1"
+version = "2025.8.0"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-migrator"
-version = "2025.7.1"
+version = "2025.8.0"
 edition = "2024"
 authors = ["stvnksslr@gmail.com"]
 description = "Tool for converting various python package soltutions to use the uv solution by astral"


### PR DESCRIPTION



## 🤖 New release

* `uv-migrator`: 2025.7.1 -> 2025.8.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2025.8.0](https://github.com/stvnksslr/uv-migrator/compare/v2025.7.1...v2025.8.0) - 2025-05-24

### Added
- feat([#72](https://github.com/stvnksslr/uv-migrator/pull/72)): adding named indexes functionality (by @stvnksslr)
- *(conda)* adding conda support (by @stvnksslr)

### Fixed
- fix([#76](https://github.com/stvnksslr/uv-migrator/pull/76)): didnt have correct logic for hatch conversion (by @stvnksslr)
- add indexes before installing dependencies ([#73](https://github.com/stvnksslr/uv-migrator/pull/73)) (by @benedikt-bartscher)

### Other
- *(readme)* changing install url to support additional tools distributed from the same bucket/domain (by @stvnksslr)
- *(readme)* changing install url to support additional tools distributed from the same bucket/domain (by @stvnksslr)
- chore(cleaning up comments): (by @stvnksslr)

### Contributors

* @stvnksslr
* @benedikt-bartscher
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).