### PR TITLE
chore: release v2025.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [2025.8.1](https://github.com/stvnksslr/uv-migrator/compare/v2025.8.0...v2025.8.1) - 2025-06-06
+
+### Fixed
+- fix(misc conda issues):
+
+### Other
+- chore(fixing install script source):
 ## [2025.8.0](https://github.com/stvnksslr/uv-migrator/compare/v2025.7.1...v2025.8.0) - 2025-05-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uv-migrator"
-version = "2025.8.0"
+version = "2025.8.1"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-migrator"
-version = "2025.8.0"
+version = "2025.8.1"
 edition = "2024"
 authors = ["stvnksslr@gmail.com"]
 description = "Tool for converting various python package soltutions to use the uv solution by astral"


### PR DESCRIPTION



## 🤖 New release

* `uv-migrator`: 2025.8.0 -> 2025.8.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2025.8.1](https://github.com/stvnksslr/uv-migrator/compare/v2025.8.0...v2025.8.1) - 2025-06-06

### Fixed
- fix(misc conda issues):

### Other
- chore(fixing install script source):
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).