### PR TITLE
chore: release v2025.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [2025.10.0](https://github.com/stvnksslr/uv-migrator/compare/v2025.9.0...v2025.10.0) - 2026-01-03
+
+### Added
+- *(fixes for parsing + test gaps for poetry)* ([#83](https://github.com/stvnksslr/uv-migrator/pull/83)) (by @stvnksslr)
+
+### Fixed
+- *(requirements)* skip pip configuration flags in requirements files ([#85](https://github.com/stvnksslr/uv-migrator/pull/85)) (by @itsbrex)
+
+### Contributors
+
+* @itsbrex
+* @stvnksslr
 ## [2025.9.0](https://github.com/stvnksslr/uv-migrator/compare/v2025.8.3...v2025.9.0) - 2025-10-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uv-migrator"
-version = "2025.9.0"
+version = "2025.10.0"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uv-migrator"
-version = "2025.9.0"
+version = "2025.10.0"
 edition = "2024"
 authors = ["stvnksslr@gmail.com"]
 description = "Tool for converting various python package soltutions to use the uv solution by astral"


### PR DESCRIPTION



## 🤖 New release

* `uv-migrator`: 2025.9.0 -> 2025.10.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2025.10.0](https://github.com/stvnksslr/uv-migrator/compare/v2025.9.0...v2025.10.0) - 2026-01-03

### Added
- *(fixes for parsing + test gaps for poetry)* ([#83](https://github.com/stvnksslr/uv-migrator/pull/83)) (by @stvnksslr)

### Fixed
- *(requirements)* skip pip configuration flags in requirements files ([#85](https://github.com/stvnksslr/uv-migrator/pull/85)) (by @itsbrex)

### Contributors

* @itsbrex
* @stvnksslr
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).