### PR TITLE
fix(requirements): skip pip configuration flags in requirements files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ Temporary Items
 .apdisk
 *.iml
 .intentionally-empty-file.o
+
+# AI/LLM project directories
+.specstory/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,136 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+UV Migrator is a Rust CLI tool that migrates Python projects from various dependency management systems (Poetry, Pipenv, requirements.txt, setup.py, Conda) to the UV package manager. It handles dependency extraction, project initialization, and configuration migration while preserving existing project settings.
+
+**Important**: This project is not associated with Astral or the uv project.
+
+## Development Commands
+
+### Building and Testing
+
+```bash
+# Build the project (requires Rust/Cargo via mise)
+cargo build
+
+# Run tests
+cargo test
+
+# Run a specific test
+cargo test <test_name>
+
+# Build release version
+cargo build --release
+
+# Run the CLI locally
+cargo run -- [OPTIONS] [PATH]
+```
+
+### Installation Options
+
+Users can install via:
+- Install script: `curl https://files.stvnksslr.com/uv-migrator/install.sh | bash`
+- Cargo: `cargo install uv-migrator`
+
+## Architecture
+
+### Core Migration Flow
+
+The migration process follows a trait-based architecture with two main abstractions:
+
+1. **MigrationSource** (src/migrators/mod.rs:20-23): Extracts dependencies from source projects
+2. **MigrationTool** (src/migrators/mod.rs:26-37): Prepares projects and adds dependencies
+
+Main entry point: `run_migration()` in src/migrators/mod.rs:307
+
+### Migration Workflow
+
+1. **Detection** (src/migrators/detect.rs): Auto-detects project type via file presence:
+   - Conda: environment.yml or environment.yaml
+   - Poetry: pyproject.toml with [tool.poetry] or [project] sections
+   - Pipenv: Pipfile
+   - setup.py: setup.py file
+   - Requirements: requirements*.txt files
+
+2. **Extraction**: Project-specific migrators extract dependencies into common `Dependency` model
+
+3. **Initialization**: `UvTool` prepares new UV project:
+   - Backs up existing pyproject.toml to old.pyproject.toml
+   - Runs `uv init` with appropriate flags (--package for packages, --bare for newer UV versions)
+   - Handles Python version constraints from original project
+
+4. **Migration**: Adds dependencies via `uv add` grouped by type (Main/Dev/Group)
+
+5. **Cleanup**: Project-specific post-processing and file cleanup
+
+### Key Components
+
+**Models** (src/models/):
+- `Dependency`: Core dependency representation with name, version, type (Main/Dev/Group), extras, environment markers
+- `ProjectType`: Enum for Poetry/Pipenv/Requirements/SetupPy/Conda
+- `PoetryProjectType`: Distinguishes Application vs Package projects
+
+**Migrators** (src/migrators/):
+- Each source has its own migrator implementing `MigrationSource`
+- `common.rs`: Shared migration logic for handling custom package indexes, author info, build systems
+- `format_dependency()`: Converts internal Dependency model to UV CLI format
+
+**Utils** (src/utils/):
+- `file_ops.rs`: FileTracker system for automatic rollback on migration errors
+- `uv.rs`: UvCommandBuilder for constructing UV CLI commands
+- `pyproject.rs`: TOML parsing and manipulation helpers
+- `pip.rs`: Handles ~/.pip/pip.conf parsing for custom indexes
+
+**Error Handling** (src/error.rs):
+- Custom error types for file operations, UV commands, dependencies, TOML parsing
+- FileTrackerGuard implements automatic rollback via Drop trait when restore_enabled=true
+
+### Version Compatibility
+
+The tool checks UV version (src/migrators/mod.rs:127-156) to determine feature availability:
+- UV >= 0.5.11: Uses `--bare` flag to avoid creating hello.py
+- Older versions: Manually cleans up hello.py after init
+
+### Important Implementation Details
+
+**Poetry Package Detection** (src/migrators/poetry.rs):
+- Checks for actual package structure (src/<package> or lib directory)
+- Projects with `packages` config but no real package structure are treated as applications
+- Original project type preserved for migrating package configs to Hatchling format
+
+**Dependency Formatting** (src/migrators/mod.rs:271-305):
+- Converts Poetry `^` constraints to `>=`
+- Converts `~` to `~=`
+- Handles extras, environment markers, and complex version specs
+
+**File Tracking** (src/utils/file_ops.rs):
+- All file operations tracked for automatic rollback
+- Stores original content for modified files
+- Rollback triggered on error or via `force_rollback()`
+
+**Custom Package Indexes**:
+- Supports named indexes via `--import-index name@url` format
+- Can import from global ~/.pip/pip.conf via `--import-global-pip-conf`
+- Migrated to `[tool.uv.index]` section in pyproject.toml
+
+## Testing Strategy
+
+Tests are integration-focused, using tempfile for isolated test environments:
+- Each migrator has dedicated test file (poetry_test.rs, pipenv_test.rs, etc.)
+- Tests verify complete migration flow: source → UV project
+- Specific tests for edge cases (git dependencies, package configs, version constraints)
+- `dependency_format_test.rs`: Tests dependency string formatting
+- `file_tracker_test.rs`: Tests rollback functionality
+
+## CLI Options
+
+Key flags:
+- `--merge-groups`: Consolidates all dependency groups into dev dependencies
+- `--import-global-pip-conf`: Import extra-index-url from ~/.pip/pip.conf
+- `--import-index [name@]url`: Add custom package indexes
+- `--disable-restore`: Skip automatic rollback on errors
+- `--self-update`: Update uv-migrator to latest version
+- `--check-update`: Check for updates without installing


### PR DESCRIPTION
## 🐛 Problem

When migrating projects with `requirements-dev.txt` files that reference other requirements files (using `-r requirements.txt`), uv-migrator crashes with a confusing error:

```
[INFO ] Adding Dev dependencies
[INFO ] Executing UV command: ["add", "--dev", "-r requirements.txt", "pytest>=7.0.0", ...]
[ERROR] Error: UV command failed: Failed to add Dev dependencies: UV command failed: 
        error: File not found: ` requirements.txt`
```

**Root Cause**: The migrator was treating pip configuration flags like `-r requirements.txt`, `--index-url`, and `-c constraints.txt` as package names and passing them directly to `uv add`, which doesn't understand pip's flag syntax.

## ✅ Solution

This PR fixes the migration by detecting and skipping pip configuration flags before passing dependencies to `uv add`. The migrator now correctly distinguishes between:
- **Package names** (e.g., `pytest>=7.0.0`) → passed to uv
- **Pip config flags** (e.g., `-r requirements.txt`) → logged and skipped

### Value Delivered

✨ **Before**: Migration failed with cryptic "File not found" errors on projects with nested requirements files  
✨ **After**: Clean migration that extracts actual packages while safely ignoring pip-specific configuration

This makes uv-migrator robust against real-world requirements files that use:
- Nested requirements: `-r`/`--requirement`
- Constraints files: `-c`/`--constraint`
- Custom indexes: `--index-url`/`--extra-index-url`
- Other pip flags: `-f`, `--trusted-host`, `--pre`, `--require-hashes`, etc.

## 🔧 Technical Changes

### Implementation Details

**New Functions**:
- `check_flag_match()` - Detects flags in all formats (short/long, with/without space, equals syntax)
  ```rust
  // Handles: -r file.txt, --requirement file.txt, --requirement=file.txt
  ```
- `is_pip_config_flag()` - Categorizes and logs skipped flags by priority

**Updated Behavior**:
- **Priority flags** logged at INFO level: `-r`, `-c`, `-i`, `--index-url`, `--extra-index-url`
- **Other flags** logged at DEBUG level: `-f`, `--find-links`, `--trusted-host`, `--no-index`, etc.
- **Editable installs** (`-e`/`--editable`) still processed to extract package info

### Files Changed
- `src/migrators/requirements.rs` - Core fix (skipping logic)
- `tests/requirements_text_test.rs` - 6 new comprehensive tests

## ✅ Test Coverage

All tests passing (57 total). New tests cover:

| Test | Scenario |
|------|----------|
| `test_skip_requirement_flags` | `-r` in all formats (short/long/equals) |
| `test_skip_constraint_flags` | `-c`/`--constraint` variations |
| `test_skip_index_url_flags` | `--index-url`/`--extra-index-url` |
| `test_skip_other_pip_flags` | Misc flags (`--pre`, `--trusted-host`, etc.) |
| `test_mixed_pip_flags_and_packages` | Real-world mixed content |
| `test_package_names_not_confused_with_flags` | Ensures `redis`/`requests` aren't skipped |

## 📝 Other Changes

- Added `CLAUDE.md` - Documentation for AI assistant context
- Added `.specstory/` to `.gitignore`

---

**Impact**: This fix unblocks users migrating from setuptools/pip-based projects that follow standard Python packaging patterns with nested requirements files.